### PR TITLE
Change devcontainer base image to a Python base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,12 +46,9 @@
   "features": {
     "ghcr.io/devcontainers-contrib/features/poetry:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers/features/python:1": {
-      "installTools": false
-    }
+    "ghcr.io/devcontainers/features/node:1": {}
   },
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "name": "Asynchronous Python client for Tailwind garage door openeners",
   "updateContentCommand": ". ${NVM_DIR}/nvm.sh && nvm install && nvm use && npm install && poetry install --extras cli && poetry run pre-commit install"
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Known compatible and tested Tailwind devices:
 
 - [Tailwind iQ3](https://gotailwind.com/products/iq3-smart-garage-controller)
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > This library requires your Tailwind device to run at least firmware version v10.10.
 
 For the development of this package, the hardware was kindly sponsored


### PR DESCRIPTION
# Proposed Changes

The Python feature for dev containers relies on the OS version by default.

Adding others, may cause compile time, so change the base image instead.
