### PR TITLE
Extract logic to convert device ID into a mac address for re-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To open a door:
 tailwind open --host 192.168.1.123
 ```
 
-For more details, access the build-in help of the CLI using the `--help` flag.
+For more details, access the built-in help of the CLI using the `--help` flag.
 
 ## Python usage
 

--- a/src/gotailwind/__init__.py
+++ b/src/gotailwind/__init__.py
@@ -33,8 +33,10 @@ from .models import (
     TailwindResponse,
 )
 from .tailwind import Tailwind
+from .util import tailwind_device_id_to_mac_address
 
 __all__ = [
+    "tailwind_device_id_to_mac_address",
     "Tailwind",
     "TailwindAuthenticationError",
     "TailwindConnectionError",

--- a/src/gotailwind/models.py
+++ b/src/gotailwind/models.py
@@ -16,6 +16,7 @@ from gotailwind.const import (
     TailwindResponseResult,
 )
 from gotailwind.exceptions import TailwindAuthenticationError, TailwindResponseError
+from gotailwind.util import tailwind_device_id_to_mac_address
 
 _RequestData = TypeVar("_RequestData")
 _ResponseT = TypeVar("_ResponseT")
@@ -141,9 +142,7 @@ class TailwindDeviceStatus(TailwindResponse):
     @property
     def mac_address(self) -> str:
         """Return the mac address."""
-        return ":".join(
-            [part.zfill(2) for part in self.device_id.strip("_").split("_")]
-        )
+        return tailwind_device_id_to_mac_address(self.device_id)
 
 
 @dataclass(kw_only=True)

--- a/src/gotailwind/util.py
+++ b/src/gotailwind/util.py
@@ -1,0 +1,6 @@
+"""Asynchronous Python client for Tailwind garage door openers."""
+
+
+def tailwind_device_id_to_mac_address(device_id: str) -> str:
+    """Convert a Tailwind device ID to a MAC address."""
+    return ":".join([part.zfill(2) for part in device_id.strip("_").split("_")])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,8 @@
+"""Asynchronous Python client for Tailwind garage door openers."""
+
+from gotailwind.util import tailwind_device_id_to_mac_address
+
+
+def test_tailwind_device_id_to_mac_address() -> None:
+    """Test tailwind_device_id_to_mac_address."""
+    assert tailwind_device_id_to_mac_address("3c_e9_0e_6d_21_84") == "3c:e9:0e:6d:21:84"


### PR DESCRIPTION
# Proposed Changes

Extracting this method, so Home Assistant can use this for converting a device ID to MAC address when a device is discovered on the network using zerconf.
